### PR TITLE
fix regex missing number range

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,9 @@ const styles = Object.keys(dependencies).reduce((acc, dependency) => {
 const outputFolder = `${src}/plugins`;
 const outputFile = `${outputFolder}/fontawesome-autoimport.js`;
 
-const { pattern = `\[['"](fa[a-z])['"], *['"]([a-z-]+)['"]\]` } = process.env;
+const {
+  pattern = `\[['"](fa[a-z])['"], *['"]([a-z0-9-]+)['"]\]`
+} = process.env;
 const faRegex = new RegExp(pattern, "g");
 const fileRegex = new RegExp(/\.(vue|js)$/);
 


### PR DESCRIPTION
This fix allow to detect and import icons with number in name like `transporter-1` for example.